### PR TITLE
docs: add Ink to npm packages page

### DIFF
--- a/src/content/docs/Development/JavaScript/npm packages.md
+++ b/src/content/docs/Development/JavaScript/npm packages.md
@@ -64,6 +64,10 @@ Curated npm packages by category. For publishing packages, see [npm Trusted Publ
 
 - **[nprogress](https://ricostacruz.com/nprogress/)** — slim progress bar for page load and async operations
 
+## CLI
+
+- **[Ink](https://github.com/vadimdemedes/ink)** — React renderer for interactive command-line apps; uses Yoga for Flexbox layouts in the terminal
+
 ## Services
 
 - **[NPM Trends](https://www.npmtrends.com/)** — compare npm package download counts over time


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds [Ink](https://github.com/vadimdemedes/ink) to the NPM packages page under a new **CLI** section.

Ink is a React renderer for building interactive command-line apps, using Yoga for Flexbox layouts in the terminal. Used by Claude Code, Gemini CLI, Shopify CLI, Cloudflare Wrangler, and many others.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4634af8-ded4-4621-a7b3-b435acde721a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4634af8-ded4-4621-a7b3-b435acde721a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

