### PR TITLE
docs: add Lapce to code editors

### DIFF
--- a/src/content/docs/macOS/Apps/Code editors.md
+++ b/src/content/docs/macOS/Apps/Code editors.md
@@ -2,7 +2,7 @@
 title: Code editors
 description: Code editors and IDEs for macOS, from lightweight text editors to full-featured JetBrains IDEs.
 created: 2026-03-12
-updated: 2026-04-07
+updated: 2026-04-10
 ---
 
 Code editors and IDEs available on macOS.
@@ -13,6 +13,7 @@ Code editors and IDEs available on macOS.
 - **[Sublime Text](https://www.sublimetext.com/)** — fast editor known for multiple cursors, the command palette, and a rich plugin ecosystem
 - **[CodeRunner](https://coderunnerapp.com/)** — macOS editor that runs code in many languages directly from the editor; useful for quick scripting
 - **[TextMate](https://macromates.com/)** — open-source macOS editor that introduced snippets and scope-based settings; lightweight and keyboard-driven
+- **[Lapce](https://lap.dev/lapce)** — open-source code editor written in Rust with built-in LSP support, Vim-like modal editing, and a focus on performance
 - **[CotEditor](https://coteditor.com/)** — free and open-source plain-text editor with syntax highlighting and a native macOS interface
 - **[NeoVim](https://neovim.io/)** — modernized Vim fork with built-in LSP support, Lua-based configuration, and full Vim compatibility
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds [Lapce](https://lap.dev/lapce) to the macOS code editors page. The other three editors mentioned (Zed, Nova, Sublime Text) were already listed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3fb9b35c-17ec-445b-8358-177e59a9b31c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3fb9b35c-17ec-445b-8358-177e59a9b31c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

