### PR TITLE
docs: add self-hosted clouds section (Coolify, Dokploy)

### DIFF
--- a/src/content/docs/Development/Services/Hosting.md
+++ b/src/content/docs/Development/Services/Hosting.md
@@ -2,7 +2,7 @@
 title: Hosting
 description: Cloud and serverless hosting platforms for deploying modern web applications.
 created: 2022-11-14
-updated: 2026-04-07
+updated: 2026-04-10
 ---
 
 Overview of hosting platforms for web applications, APIs, and static sites — from serverless PaaS to dedicated cloud servers.
@@ -22,6 +22,13 @@ Overview of hosting platforms for web applications, APIs, and static sites — f
 - **[Digital Ocean](https://www.digitalocean.com/)** — straightforward cloud hosting with VMs, managed databases, and app platform
 - **[Kinsta](https://kinsta.com/application-hosting/)** — application and database hosting on Google Cloud
 - **[Amazon S3](https://aws.amazon.com/s3/)** — object storage service, commonly used for static asset hosting
+
+## Self-hosted clouds
+
+Open-source PaaS platforms you run on your own server — alternatives to Vercel, Heroku, or Railway without vendor lock-in.
+
+- **[Coolify](https://coolify.io/)** — self-hostable alternative to Vercel / Netlify / Railway with Git push-to-deploy, automatic SSL, database backups, and 280+ one-click services
+- **[Dokploy](https://dokploy.com/)** — open-source deployment platform with Docker Compose support, multi-server management, Traefik integration, and built-in database backups
 
 ## GitHub Pages subdomains
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new **Self-hosted clouds** section to the Hosting page (`Development/Services/Hosting.md`) with two open-source PaaS platforms:

- **[Coolify](https://coolify.io/)** — self-hostable alternative to Vercel / Netlify / Railway with Git push-to-deploy, automatic SSL, database backups, and 280+ one-click services
- **[Dokploy](https://dokploy.com/)** — open-source deployment platform with Docker Compose support, multi-server management, Traefik integration, and built-in database backups
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c25cef5-16dc-4925-9262-0fafaa2a8262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c25cef5-16dc-4925-9262-0fafaa2a8262"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

