### PR TITLE
docs: add Ulysses to Markdown editors

### DIFF
--- a/src/content/docs/macOS/Apps/Markdown editors.md
+++ b/src/content/docs/macOS/Apps/Markdown editors.md
@@ -2,7 +2,7 @@
 title: Markdown editors
 description: Markdown and plain-text editors for macOS, from distraction-free writing apps to full knowledge bases.
 created: 2020-10-12
-updated: 2026-04-08
+updated: 2026-04-10
 ---
 
 Markdown-focused writing and note apps for macOS. For note-taking apps see also [Notes and calendar](/macos/apps/notes-and-calendar/).
@@ -12,6 +12,7 @@ Markdown-focused writing and note apps for macOS. For note-taking apps see also 
 - **[FSNotes](https://fsnot.es/)** — fast note manager supporting GitHub Flavored Markdown, TextBundle, iCloud sync, `[[wikilinks]]`, Mermaid, MathJax, tags, and optional Git versioning
 - **[Nota](https://nota.md/)** — pro Markdown notes app for local files; no account or subscription required
 - **[Bear](https://bear.app/)** — polished Markdown editor for Mac and iOS with tags and iCloud sync
+- **[Ulysses](https://ulysses.app/)** — full-featured writing app for Mac, iPad and iPhone with markup-based editor, built-in grammar and style checker, iCloud sync, writing goals, and direct publishing to WordPress, Ghost, Medium and Micro.blog (subscription)
 - **[iA Writer](https://ia.net/writer)** — minimal writing environment with focus mode, syntax highlighting for content style, and export to Word/PDF
 - **[Typora](https://typora.io/)** — WYSIWYG Markdown editor that renders formatting inline rather than showing raw syntax
 - **[Joplin](https://joplinapp.org/)** — open-source note-taking app with end-to-end encryption and sync via Nextcloud, Dropbox, or WebDAV


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add [Ulysses](https://ulysses.app/) to the Markdown editors page.

Ulysses is a full-featured writing app for Mac, iPad and iPhone with a markup-based editor, built-in grammar and style checker, iCloud sync, writing goals, and direct publishing to WordPress, Ghost, Medium and Micro.blog. It's a subscription-based app and an Apple Design Award winner.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9fac76df-4fe5-4fb4-b1ba-a9fe4ed42132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9fac76df-4fe5-4fb4-b1ba-a9fe4ed42132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

