### PR TITLE
docs: add caveman skill to Claude Code Skills page

### DIFF
--- a/src/content/docs/AI/Claude Code/Skills.md
+++ b/src/content/docs/AI/Claude Code/Skills.md
@@ -2,7 +2,7 @@
 title: Skills
 description: Curated open-source skill collections for Claude Code and AI coding agents.
 created: 2026-04-08
-updated: 2026-04-10
+updated: 2026-04-11
 ---
 
 Open-source skill collections that extend Claude Code and other AI coding agents with specialized workflows.
@@ -29,6 +29,21 @@ Open-source skill collections that extend Claude Code and other AI coding agents
   ```
 
   Key skills: `spec-driven-development`, `test-driven-development`, `security-and-hardening`, `performance-optimization`, `code-review-and-quality`, `shipping-and-launch`
+
+- **[caveman](https://github.com/JuliusBrussee/caveman)** — "why use many token when few do trick" — skill/plugin that makes the agent talk like a caveman, cutting ~75% of output tokens while keeping full technical accuracy; includes intensity levels (Lite / Full / Ultra), 文言文 classical Chinese mode, terse commit messages (`caveman-commit`), one-line code reviews (`caveman-review`), and a `caveman-compress` tool that rewrites memory files (e.g. `CLAUDE.md`) into compressed prose saving ~45% of input tokens
+
+  Install in Claude Code:
+
+  ```bash
+  claude plugin marketplace add JuliusBrussee/caveman
+  claude plugin install caveman@caveman
+  ```
+
+  Any agent (Cursor, Copilot, Windsurf, Cline, Codex):
+
+  ```bash
+  npx skills add JuliusBrussee/caveman
+  ```
 
 - **[claude-improve](https://github.com/TerenceBristol/claude-improve)** — self-improving retrospective skill; after each conversation Claude reflects on what went wrong and updates its own CLAUDE.md rules to do better next time
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds [caveman](https://github.com/JuliusBrussee/caveman) to the Claude Code Skills page — a skill/plugin that reduces output tokens by ~75% by making the agent speak in compressed "caveman" style while preserving technical accuracy.

Key features covered:
- Intensity levels (Lite / Full / Ultra)
- 文言文 classical Chinese mode
- `caveman-commit` for terse commit messages
- `caveman-review` for one-line code reviews
- `caveman-compress` for compressing memory files (~45% input token savings)
- Install instructions for Claude Code plugin and generic `npx skills` for other agents
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-318241c1-405a-4495-a4fe-7990d0c383f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-318241c1-405a-4495-a4fe-7990d0c383f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

