### PR TITLE
fix: handle TMDB API errors gracefully in Series and Movie components

### DIFF
--- a/src/components/Movie.astro
+++ b/src/components/Movie.astro
@@ -16,10 +16,16 @@ if (title.match(/\((\d{4})\)/)) {
 	url.searchParams.append('query', title);
 }
 
-const response = await fetch(url).then((r) => r.json());
-if (!response || !response.results) return null;
-
-const result = response.results.filter((result: { title: string }) => result.title.toLowerCase() === title.toLowerCase()).shift() || response.results.shift();
+let result: any = null;
+try {
+	const res = await fetch(url);
+	if (!res.ok) return null;
+	const response = await res.json();
+	if (!response?.results) return null;
+	result = response.results.find((r: { title: string }) => r.title.toLowerCase() === title.toLowerCase()) ?? response.results[0] ?? null;
+} catch {
+	return null;
+}
 if (!result) return null;
 
 const img = result.poster_path ? `https://image.tmdb.org/t/p/w500${result.poster_path}` : '';

--- a/src/components/Series.astro
+++ b/src/components/Series.astro
@@ -19,13 +19,18 @@ if (title.match(/\((\d{4})\)/)) {
 	url.searchParams.append('query', title);
 }
 
-const response = await fetch(url).then((r) => r.json());
-if (!response || !response.results) return null;
-
-const result = response.results.filter((result: { name: string }) => result.name.toLowerCase() === title.toLowerCase()).shift() || response.results.shift();
+let result: any = null;
+try {
+	const res = await fetch(url);
+	if (!res.ok) return null;
+	const response = await res.json();
+	if (!response?.results) return null;
+	result = response.results.find((r: { name: string }) => r.name.toLowerCase() === title.toLowerCase()) ?? response.results[0] ?? null;
+} catch {
+	return null;
+}
 if (!result) return null;
 
-// construct image URL and link
 const img = result.poster_path ? `https://image.tmdb.org/t/p/w500${result.poster_path}` : '';
 const link = result.id ? `https://www.themoviedb.org/tv/${result.id}` : '#';
 const name = result.name ?? title


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The GitHub Pages build was failing with:

```
SyntaxError: Unexpected token '<', "<html>\n<h"... is not valid JSON
ERROR [build] Caught error rendering /movies-and-tv/watchlist
```

The TMDB API occasionally returns an HTML error page instead of JSON (e.g. due to rate limiting or temporary outage). The `Series.astro` and `Movie.astro` components were calling `.json()` directly on the fetch response without checking the response status or handling parse errors, causing the entire Astro build to crash.

## Fix

Wrapped the TMDB API fetch + JSON parsing in both `Series.astro` and `Movie.astro` in a `try-catch` block:

- Check `res.ok` before attempting to parse JSON
- Catch any errors from `fetch()` or `res.json()` (network failures, invalid JSON, etc.)
- Return `null` on failure instead of throwing — the component simply won't render for that item, but the build completes successfully

## Files changed

- `src/components/Series.astro` — added error handling around TMDB TV search API call
- `src/components/Movie.astro` — added error handling around TMDB movie search API call
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bab82750-b1a6-4a73-afa8-5d42bced463e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab82750-b1a6-4a73-afa8-5d42bced463e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

