### PR TITLE
docs: odkaz na DigitalOcean GPU Droplet v úvodu Gemma 4

### DIFF
--- a/src/content/docs/AI/Gemma/Gemma 4 na DigitalOcean.md
+++ b/src/content/docs/AI/Gemma/Gemma 4 na DigitalOcean.md
@@ -5,7 +5,7 @@ created: 2026-04-09
 updated: 2026-04-12
 ---
 
-Praktický návod, jak spustit Gemma 4 přes [Ollama](https://ollama.com/) na DigitalOcean GPU Droplet. Postup je ověřený na Debianu 13 (Trixie) s kartou RTX 4000 Ada (20 GB VRAM), stav k dubnu 2026.
+Praktický návod, jak spustit Gemma 4 přes [Ollama](https://ollama.com/) na [DigitalOcean GPU Droplet](https://www.digitalocean.com/products/gradient/gpu-droplets). Postup je ověřený na Debianu 13 (Trixie) s kartou RTX 4000 Ada (20 GB VRAM), stav k dubnu 2026.
 
 ## Modely
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
V úvodním odstavci stránky **Gemma 4 na DigitalOcean GPU Droplet** je text „DigitalOcean GPU Droplet“ nyní odkazem na oficiální produktovou stránku, konzistentně se sekcí „GPU Droplet“ níže na stejné stránce.

**Změna:** `https://www.digitalocean.com/products/gradient/gpu-droplets`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcaa07d2-9d23-42a4-8953-697b3b6825dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcaa07d2-9d23-42a4-8953-697b3b6825dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

