### PR TITLE
docs: add Graphify wiki page

### DIFF
--- a/src/content/docs/AI/Claude Code/Skills.md
+++ b/src/content/docs/AI/Claude Code/Skills.md
@@ -2,7 +2,7 @@
 title: Skills
 description: Curated open-source skill collections for Claude Code and AI coding agents.
 created: 2026-04-08
-updated: 2026-04-11
+updated: 2026-04-12
 ---
 
 Open-source skill collections that extend Claude Code and other AI coding agents with specialized workflows.
@@ -49,5 +49,6 @@ Open-source skill collections that extend Claude Code and other AI coding agents
 
 ## 🔗 Related
 
+- [Graphify](../tools/graphify) — knowledge graph builder skill (Tree-sitter + LLM extraction) for codebase understanding
 - [Claude Code](../claude-code) — commands and settings reference
 - [Plugins](../plugins) — Claude Code plugin marketplace

--- a/src/content/docs/AI/Tools/AI Tools.md
+++ b/src/content/docs/AI/Tools/AI Tools.md
@@ -38,7 +38,7 @@ Nástroje pro tvorbu aplikací pomocí AI — generování kódu, vizuální bui
 
 ## 💻 Coding
 
-- **[Graphify](../graphify)** — open-source knowledge graph skill for AI coding assistants; builds a queryable graph from code, docs, and diagrams ([graphify.net](https://graphify.net))
+- **[Graphify](../graphify)** — open-source „skill“ pro AI coding asistenty; staví dotazovatelný graf z kódu, dokumentace a diagramů ([graphify.net](https://graphify.net))
 - **[Claude Code](https://claude.ai/code/)** — AI coding agent by Anthropic
 - **[Codex](https://openai.com/codex/)** — AI coding agent by OpenAI
 - **[GitHub Copilot](https://github.com/copilot/)** — AI coding agent integrovaný přímo do GitHubu

--- a/src/content/docs/AI/Tools/AI Tools.md
+++ b/src/content/docs/AI/Tools/AI Tools.md
@@ -2,7 +2,7 @@
 title: AI Tools
 description: Přehled AI nástrojů — chatboti, platformy, app buildery, kódování, design, generování obrázků a videa, správa znalostí a zpracování textu.
 created: 2026-04-08
-updated: 2026-04-08
+updated: 2026-04-12
 ---
 
 Přehled AI nástrojů podle kategorie použití.
@@ -38,6 +38,7 @@ Nástroje pro tvorbu aplikací pomocí AI — generování kódu, vizuální bui
 
 ## 💻 Coding
 
+- **[Graphify](../graphify)** — open-source knowledge graph skill for AI coding assistants; builds a queryable graph from code, docs, and diagrams ([graphify.net](https://graphify.net))
 - **[Claude Code](https://claude.ai/code/)** — AI coding agent by Anthropic
 - **[Codex](https://openai.com/codex/)** — AI coding agent by OpenAI
 - **[GitHub Copilot](https://github.com/copilot/)** — AI coding agent integrovaný přímo do GitHubu

--- a/src/content/docs/AI/Tools/Graphify.md
+++ b/src/content/docs/AI/Tools/Graphify.md
@@ -1,0 +1,45 @@
+---
+title: Graphify
+description: Open-source knowledge graph skill for AI coding assistants — Tree-sitter, NetworkX, Leiden clustering, and assistant-facing commands.
+created: 2026-04-12
+updated: 2026-04-12
+---
+
+[Graphify](https://graphify.net) is an open-source “skill” aimed at AI coding assistants. It builds a queryable knowledge graph from a repository’s code, documentation, PDFs, and images so assistants can reason about structure and cross-file relationships, not only retrieve text chunks.
+
+## What it does
+
+The project combines **Tree-sitter** static analysis (ASTs, call graphs, docstrings across many languages) with **LLM-based** semantic extraction from prose and **vision models** for diagrams. Extracted nodes and edges are merged into a **NetworkX** graph; **Leiden** community detection groups related parts without relying on vector embeddings. The pipeline also surfaces high-degree “god” nodes and highlights unexpected cross-file or cross-domain edges.
+
+Outputs are written under `graphify-out/`, including an interactive `graph.html`, a machine-readable `graph.json`, and a `GRAPH_REPORT.md` audit-style summary, plus a `cache/` directory for incremental work.
+
+## Install and CLI
+
+- **Python:** 3.10+ (as stated on the project site).
+- **PyPI package name:** `graphifyy`; the command-line tool is **`graphify`**.
+- Typical install: `pip install graphifyy && graphify install` (per upstream docs).
+
+Assistant-oriented slash commands advertised include `/graphify`, `/graphify query`, `/graphify path`, and `/graphify explain`. Any environment that can run shell commands can invoke `graphify`.
+
+## Models and privacy
+
+Graphify does **not** bundle an LLM. Semantic extraction uses the API key already configured in your assistant (e.g. Claude or Codex). The project states that only **semantic descriptions** are sent upstream—not full raw source files.
+
+## Pipeline (high level)
+
+Upstream documentation describes stages such as: detect → extract → build graph → cluster (Leiden) → analyze → report → export (HTML, JSON, Obsidian-oriented flows). Supporting pieces include modules for URL ingest, caching, validation, optional watch mode, and an MCP-oriented serve path.
+
+## Reported examples
+
+The site documents illustrative runs (exact numbers are claims from the project, not independently verified here):
+
+- A small **httpx**-style corpus: on the order of hundreds of nodes and edges, with named “god” nodes such as client and request/response types.
+- A larger mixed corpus (code repos, papers, diagrams): roughly **71.5×** fewer tokens for queries versus a naive baseline in their scenario, as claimed on the marketing page.
+
+## Security posture (as described by the project)
+
+The documentation emphasizes strict handling of URLs (http/https only), size and time limits on downloads, path containment checks, and HTML escaping of labels to reduce SSRF, injection, and XSS risks. The project reports **no telemetry**; outbound calls are tied to semantic extraction via your configured model API.
+
+## Sources
+
+- [Graphify](https://graphify.net) — product overview, install snippet, pipeline, examples, comparison table, FAQ, and security notes (accessed 2026-04-12)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a new English wiki page summarizing [Graphify](https://graphify.net): multi-modal knowledge graph skill for AI coding assistants (Tree-sitter, NetworkX, Leiden clustering, outputs, install via `graphifyy`, privacy and security claims as stated on the site).

Also links the page from the AI Tools index (Czech list page) and from Claude Code Skills for discoverability.

**Note:** `astro check` passes. Full `npm run build` fails in this environment without `TMDB_API_KEY` when prerendering Movies & TV pages (pre-existing; unrelated to these doc-only changes).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eea70076-3305-4ad1-b861-3a1119c16950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eea70076-3305-4ad1-b861-3a1119c16950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

