### PR TITLE
docs: add AirCube IoT air quality wiki page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "ozzyczech.cz",
+	"name": "workspace",
 	"version": "0.0.1",
 	"lockfileVersion": 3,
 	"requires": true,

--- a/src/content/docs/Hardware/IoT/AirCube.md
+++ b/src/content/docs/Hardware/IoT/AirCube.md
@@ -1,0 +1,52 @@
+---
+title: AirCube
+description: Zigbee air quality sensor for Home Assistant — VOC, CO2, temperature, humidity, and AQI; local-only, open hardware from StuckAtPrototype.
+created: 2026-04-12
+updated: 2026-04-12
+sidebar:
+  order: 10
+---
+
+AirCube is a small **Zigbee 3.0** air quality device aimed at **Home Assistant**: pair it with a coordinator and you get five sensor entities without cloud accounts. The same hardware works **standalone** over USB-C as a simple traffic-light style indicator (green / yellow / red) when you do not use a mesh network yet. The vendor listed it at **$59** on the product page when this note was written (see Sources).
+
+## Home Assistant integration
+
+You need a **Zigbee coordinator** (for example a USB dongle) on the machine that runs Home Assistant. The vendor documents support for **ZHA** and **Zigbee2MQTT** via a **custom quirk** (ZHA) and **external converter** (Zigbee2MQTT), shipped with their documentation. After pairing, the device is described as reporting about **once per second**. All processing stays on your LAN.
+
+### Entities
+
+| Entity | Role | Unit |
+| --- | --- | --- |
+| `temperature` | Room temperature | °C |
+| `humidity` | Relative humidity | % |
+| `co2` | Estimated CO₂ | ppm |
+| `tvoc` | Total volatile organic compounds | ppb |
+| `aqi` | Air quality index | — |
+
+Temperature and humidity are picked up automatically; CO₂, TVOC, and AQI rely on the custom integration pieces above.
+
+### Automations
+
+Typical uses include turning on ventilation or a fan when VOCs or AQI cross a threshold, or notifying when air quality degrades. Each device exposes its own set of entities, so multiple units can cover different rooms.
+
+## Standalone use
+
+Without Home Assistant or a coordinator, powering the cube via **USB-C** makes the **RGB LED** reflect air quality: green (good), yellow (consider ventilating), red (needs attention). No Wi‑Fi, app, or account is required.
+
+## Hardware overview
+
+| Aspect | Details |
+| --- | --- |
+| MCU | ESP32-H2 (native Zigbee radio) |
+| Sensors | ScioSense ENS161 (VOC / eCO₂), ENS210 (temperature, humidity) |
+| Connectivity | Zigbee 3.0 |
+| Indicator | Addressable RGB LED (part referenced as IN-PI15TAT5R5G5B on vendor materials) |
+| Power | USB-C, 5 V |
+| Size | 49 × 49 × 36 mm |
+| Enclosure | 3D-printed PLA with diffused top |
+
+Firmware, schematics, PCB layout, and BOM are described as **open source** on the vendor’s GitHub; the product is designed and assembled in Texas (USA).
+
+## Sources
+
+- [AirCube product overview — StuckAtPrototype](https://stuckatprototype.com/pages/aircube) — specifications, HA entities, standalone behaviour, and integration notes (accessed 2026-04-12)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This change adds a new wiki page for the AirCube, a Zigbee air quality sensor from StuckAtPrototype that integrates with Home Assistant (ZHA and Zigbee2MQTT) and can run standalone over USB-C with a color-coded LED.

The page summarizes entities, automation ideas, hardware specs (ESP32-H2, ENS161/ENS210), and cites the vendor product page as the source. It lives under `Hardware/IoT` next to other IoT notes.

A small `package-lock.json` update is included from running `npm install` during verification.

**Verification:** `npx astro check` passes. Full `astro build` fails in this environment because `TMDB_API_KEY` is not set for an unrelated MDX page; the new Markdown page renders in the build log before that failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a98ef1-984a-4ee0-815f-342ccc9cc8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a98ef1-984a-4ee0-815f-342ccc9cc8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

