### PR TITLE
docs: add Pliny.gg overview page

### DIFF
--- a/src/content/docs/AI/Tools/AI Tools.md
+++ b/src/content/docs/AI/Tools/AI Tools.md
@@ -2,7 +2,7 @@
 title: AI Tools
 description: Přehled AI nástrojů — chatboti, platformy, app buildery, kódování, design, generování obrázků a videa, správa znalostí a zpracování textu.
 created: 2026-04-08
-updated: 2026-04-12
+updated: 2026-04-18
 ---
 
 Přehled AI nástrojů podle kategorie použití.
@@ -39,6 +39,7 @@ Nástroje pro tvorbu aplikací pomocí AI — generování kódu, vizuální bui
 ## 💻 Coding
 
 - **[Graphify](../graphify)** — open-source „skill“ pro AI coding asistenty; staví dotazovatelný graf z kódu, dokumentace a diagramů ([graphify.net](https://graphify.net))
+- **[Pliny.gg](../pliny-the-prompter)** — veřejný rozcestník kolem red teamingu LLM, transparentnosti a souvisejících projektů (přehled z [pliny.gg](https://pliny.gg), bez jailbreak textů)
 - **[Claude Code](https://claude.ai/code/)** — AI coding agent by Anthropic
 - **[Codex](https://openai.com/codex/)** — AI coding agent by OpenAI
 - **[GitHub Copilot](https://github.com/copilot/)** — AI coding agent integrovaný přímo do GitHubu

--- a/src/content/docs/AI/Tools/Pliny the Prompter.md
+++ b/src/content/docs/AI/Tools/Pliny the Prompter.md
@@ -1,0 +1,61 @@
+---
+title: Pliny.gg
+description: Public hub for “Pliny the Prompter” — red teaming, prompt research, linked projects, and press coverage (overview from pliny.gg as of 2026-04-18).
+created: 2026-04-18
+updated: 2026-04-18
+---
+
+[Pliny.gg](https://pliny.gg) is a personal site that brands itself around **“Pliny the Prompter”** and frames work as AI red teaming, transparency, and community research. The homepage mixes project links, press quotes, academic citations, and historical notes about **Pliny the Elder** (the Roman author and naturalist).
+
+:::caution
+The live site can embed **adversarial prompt text** (attempts to override model instructions). This page summarizes **only** public project names and links from the site; it does **not** reproduce jailbreak payloads or instructions.
+:::
+
+## Projects and platforms linked from the site
+
+| Name (as on site) | What the site describes | Link |
+| --- | --- | --- |
+| L1B3RT4S | Collection of jailbreak and “liberation” prompts for major LLMs (GitHub repo) | [github.com/elder-plinius/L1B3RT4S](https://github.com/elder-plinius/L1B3RT4S) |
+| CL4R1T4S | System prompt transparency / leaked-style documentation (GitHub repo) | [github.com/elder-plinius/CL4R1T4S](https://github.com/elder-plinius/CL4R1T4S) |
+| R3D4R3N4 | Gamified red teaming platform with leaderboards | [redarena.ai](https://redarena.ai/) |
+| L34KHVB | Community leaderboard for leaked AI system prompts | [leakhub.ai](https://leakhub.ai/) |
+| G0DM0D3 | Third-party “unrestricted” AI product link | [godmod3.ai](https://godmod3.ai/) |
+| P4RS3LT0NGV3 | Prompt engineering / payload crafting notes (GitHub Pages) | [elder-plinius.github.io/P4RS3LT0NGV3](https://elder-plinius.github.io/P4RS3LT0NGV3/) |
+| ST3GG | Steganography toolkit (encoding, media, detection) | [ste.gg](https://www.ste.gg/) |
+| GL0SS0P3TR43 | Procedural language / steganography-related experiment (GitHub Pages) | [elder-plinius.github.io/GLOSSOPETRAE](https://elder-plinius.github.io/GLOSSOPETRAE/) |
+| BASI COMMUNITY | Discord for red teamers and prompt researchers | [discord.gg/basi](https://discord.gg/basi) |
+| BT6 | “Frontier AI red team” collective | [bt6.gg](https://bt6.gg/) |
+| V3SP3R | Hardware-oriented AI companion project (GitHub) | [github.com/elder-plinius/V3SP3R](https://github.com/elder-plinius/V3SP3R) |
+| PL1NY.TV | Video / “from the lab” content | [pliny.tv](https://pliny.tv/) |
+| 0BL1T3R4TUS | Toolkit described as removing refusal behaviors without full retraining (GitHub) | [github.com/elder-plinius/OBLITERATUS](https://github.com/elder-plinius/OBLITERATUS) |
+
+## Press and recognition (as listed on the site)
+
+The homepage highlights third-party coverage and quotes, including:
+
+- **TIME** — TIME100 AI 2025 feature: [Pliny the Liberator](https://time.com/collections/time100-ai-2025/7305870/pliny-the-liberator/) (accessed 2026-04-18)
+- **BBC** — “AI Decoded” video: [YouTube](https://www.youtube.com/watch?v=Fg9hCKH1sYs) (accessed 2026-04-18)
+- **Financial Times** — article on AI jailbreakers: [FT](https://www.ft.com/content/14a2c98b-c8d5-4e5b-a7b0-30f0a05ec432) (accessed 2026-04-18; paywalled)
+- **VentureBeat** — interview: [venturebeat.com](https://venturebeat.com/ai/an-interview-with-the-most-prolific-jailbreaker-of-chatgpt-and-other-leading-llms/) (accessed 2026-04-18)
+- **Futurism** — article referencing “Godmode”: [futurism.com](https://futurism.com/hackers-jailbroken-chatgpt-godmode) (accessed 2026-04-18)
+- **Google Cloud Threat Intelligence** — adversarial misuse blog: [cloud.google.com](https://cloud.google.com/blog/topics/threat-intelligence/adversarial-misuse-generative-ai) (accessed 2026-04-18)
+- **Mozilla 0din** — “Poison in the Pipeline” post: [0din.ai](https://0din.ai/blog/poison-in-the-pipeline-liberating-models-with-basilisk-venom) (accessed 2026-04-18)
+- **Decrypt** — ban/unban reporting: [decrypt.co](https://decrypt.co/313007/violent-activity-on-chatgpt-gets-famed-ai-hacker-pliny-banned-then-unbanned) (accessed 2026-04-18)
+
+Short attributed quotes on the same page name **Decrypt**, **BBC AI Decoded**, and **Eliezer Yudkowsky** as sources for pull-quote blurbs (verbatim text not reproduced here).
+
+## Academic citations section (names only)
+
+The site’s “academic citations” block lists paper titles and venues/years, including (non-exhaustive): **AutoRedTeamer** (arXiv:2503.15754; listed as ICLR 2025 submission), **Plentiful Jailbreaks with String Compositions** (arXiv:2411.01084; NeurIPS 2024 SoLaR), **Endless Jailbreaks with Bijection Learning** (arXiv:2410.01294), **Mixture of Tunable Experts** (DeepSeek-R1; arXiv:2502.11096), **Constitutional Classifiers** (arXiv:2501.18837), **RoboPAIR** (2024), **Jailbreak-Zero** (arXiv:2601.03265), **Jailbreak Paradox** (arXiv:2406.12702), **Investigator Agents** (Transluce / UC Berkeley; 2025), and **Adaptive Attacks on Trusted Monitors** (arXiv:2510.09462; listed as ICLR 2026). Treat arXiv IDs and venue labels as **claims copied from the marketing page**; verify on the papers themselves before citing academically.
+
+## Historical “fun facts” block
+
+The site includes brief popular-history notes about **Pliny the Elder** (Vesuvius, *Natural History*, basilisk folklore, cannabis notes, “in vino veritas”, and a modern beer name). These are **anecdotal** summaries on a personal homepage, not a scholarly history source.
+
+## Related wiki notes
+
+For a structured catalog of mainstream AI tools and platforms, see [AI Tools](../ai-tools).
+
+## Sources
+
+- [Pliny.gg](https://pliny.gg) — project list, press links, quotes block, academic citations list, and historical trivia (retrieved 2026-04-18)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new wiki page that summarizes [Pliny.gg](https://pliny.gg) as a public hub for AI red teaming and transparency work: linked projects, press coverage URLs, and the academic-citations list (as presented on the site). The page explicitly avoids copying adversarial prompt text from the live homepage.

Also links the page from `AI Tools` for discoverability.

## Notes

- `npx astro check` passes locally.
- Full `npm run build` fails in this environment without `TMDB_API_KEY` while prerendering `Movies & TV` content (pre-existing constraint, unrelated to this change).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-254ed66a-0a11-4675-9f28-1922aee79202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-254ed66a-0a11-4675-9f28-1922aee79202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

