### PR TITLE
ci: use wiki-publisher@main in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: OzzyCzech/wiki-publisher@v1
+      - uses: OzzyCzech/wiki-publisher@main
         env:
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update the deploy workflow to reference `OzzyCzech/wiki-publisher@main` instead of `@v1`, so each run uses the current tip of the publisher repository.

**Note:** This tracks a moving branch; builds may change when `main` changes. Pinning to a tag or SHA remains an option if reproducibility is preferred.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9f6f8fab-bc30-489e-9aa1-1309ab599716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f6f8fab-bc30-489e-9aa1-1309ab599716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

